### PR TITLE
Update nginx config (resolves #1)

### DIFF
--- a/services/web/nginx.conf.template
+++ b/services/web/nginx.conf.template
@@ -41,7 +41,8 @@ server {
       ngx.req.read_body()  -- explicitly read the req body
       local body = ngx.req.get_body_data()
       if body then
-        body = ngx.re.gsub(body, "://"..ngx.var.http_host, "://${WORKSHOP_SERVICE}")
+        body = ngx.re.gsub(body, "https://"..ngx.var.http_host, "http://${WORKSHOP_SERVICE}")
+        body = ngx.re.gsub(body, "http://"..ngx.var.http_host, "http://${WORKSHOP_SERVICE}")
         ngx.req.set_body_data(body)
       end
     }


### PR DESCRIPTION
The API is passing around a URL to the next api it should call in the body. Original rewrite rule wasn't rewriting the https to http, so when doing the "local" call between services it was failing.