### PR TITLE
Deploy gateway service for order payment mock

### DIFF
--- a/deploy/helm/templates/api-gateway-service/deployment.yaml
+++ b/deploy/helm/templates/api-gateway-service/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: {{ .Values.apiGatewayService.name }}
-          image: {{ .Values.apiGatewayService.image }}:{{ .Chart.AppVersion }}
+          image: {{ .Values.apiGatewayService.image }}:latest
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           ports:
             - containerPort: {{ .Values.apiGatewayService.port }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -6,8 +6,8 @@ jwtSecret: crapi
 enableLog4j: true
 enableShellInjection: true
 imagePullPolicy: Always
-apiGatewayServiceUrl: https://api.mypremiumdealership.com
-apiGatewayServiceInstall: false
+apiGatewayServiceUrl: https://gateway-service
+apiGatewayServiceInstall: true
 apiGatewayPassword:
 tlsEnabled: true
 jwtExpiration: 604800000


### PR DESCRIPTION
This fixes an issue that was preventing the orders API from fetching an order. Instead of relying on an external deployment of the gateway service, use a self-deployed verison.